### PR TITLE
Add notice explaining project is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 COBA, Chase Online Banking Agent
 ================================
 
+**This project is no longer maintained, and the author does not have any
+recommendations for a replacement.**
+
 COBA is a Python library that provides an interface to Chase Online Banking by
 scraping the mobile version of the Chase Online website.
 


### PR DESCRIPTION
Add a notice explaining the project is no longer maintained in hopes of staving
off people contacting me about this long-dead project.